### PR TITLE
Do not log exception twice.

### DIFF
--- a/src/Curiosity.Migrations.PostgreSQL/CHANGELOG.md
+++ b/src/Curiosity.Migrations.PostgreSQL/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2] - 2020-10-16
+
+### Fixed
+
+- Exceptions occurred during upgrade or downgrade were logged twice.
+
 ## [2.1] - 2020-09-21
 
 ### Changed

--- a/src/Curiosity.Migrations.PostgreSQL/Curiosity.Migrations.PostgreSQL.csproj
+++ b/src/Curiosity.Migrations.PostgreSQL/Curiosity.Migrations.PostgreSQL.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
 
         <PackageId>Curiosity.Migrations.PostgreSQL</PackageId>
-        <Version>2.1</Version>
+        <Version>2.2</Version>
         <Authors>Maxim Markelow, Andrei Vinogradov</Authors>
         <Company>SIIS Ltd</Company>
         <PackageLicenseUrl>https://github.com/SIIS-Ltd/Migrations/blob/master/LICENSE/</PackageLicenseUrl>

--- a/src/Curiosity.Migrations.PostgreSQL/Properties/AssemblyInfo.cs
+++ b/src/Curiosity.Migrations.PostgreSQL/Properties/AssemblyInfo.cs
@@ -19,5 +19,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("527ae969-df3b-487c-8032-f3476d793e08")]
 
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.2.0")]
+[assembly: AssemblyFileVersion("2.2.0")]

--- a/src/Curiosity.Migrations/CHANGELOG.md
+++ b/src/Curiosity.Migrations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2] - 2020-10-16
+
+### Fixed
+
+- Exceptions occurred during upgrade or downgrade were logged twice.
+
 ## [2.1] - 2020-09-21
 
 ### Added

--- a/src/Curiosity.Migrations/Curiosity.Migrations.csproj
+++ b/src/Curiosity.Migrations/Curiosity.Migrations.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         
         <PackageId>Curiosity.Migrations</PackageId>
-        <Version>2.1</Version>
+        <Version>2.2</Version>
         <Authors>Maxim Markelow, Kirill Lutsenko, Andrei Vinogradov</Authors>
         <Company>SIIS Ltd</Company>
         <PackageLicenseUrl>https://github.com/SIIS-Ltd/Migrations/blob/master/LICENSE/</PackageLicenseUrl>

--- a/src/Curiosity.Migrations/DbMigrator.cs
+++ b/src/Curiosity.Migrations/DbMigrator.cs
@@ -281,11 +281,6 @@ namespace Curiosity.Migrations
 
                     _logger?.LogInformation($"Upgrade to {migration.Version} (DB {_dbProvider.DbName}) completed.");
                 }
-                catch (Exception e)
-                {
-                    _logger?.LogError(e, $"Error while upgrade to {migration.Version}: {e.Message}");
-                    throw;
-                }
                 finally
                 {
                     transaction?.Dispose();
@@ -368,27 +363,18 @@ namespace Curiosity.Migrations
 
                 using (var transaction = _dbProvider.BeginTransaction())
                 {
-                    try
-                    {
-                        _logger?.LogInformation(
-                            $"Downgrade to {desiredMigrations[i + 1].Version} (DB {_dbProvider.DbName})...");
-                        await downgradeMigration.DowngradeAsync(transaction, token);
-                        await _dbProvider.UpdateCurrentDbVersionAsync(downgradeMigration.Comment, targetLocalVersion, token);
-                        lastMigrationVersion = targetLocalVersion;
-                        currentDbVersion = targetLocalVersion;
+                    _logger?.LogInformation(
+                        $"Downgrade to {desiredMigrations[i + 1].Version} (DB {_dbProvider.DbName})...");
+                    await downgradeMigration.DowngradeAsync(transaction, token);
+                    await _dbProvider.UpdateCurrentDbVersionAsync(downgradeMigration.Comment, targetLocalVersion, token);
+                    lastMigrationVersion = targetLocalVersion;
+                    currentDbVersion = targetLocalVersion;
 
-                        // Commit transaction if all commands succeed, transaction will auto-rollback
-                        // when disposed if either commands fails
-                        transaction.Commit();
+                    // Commit transaction if all commands succeed, transaction will auto-rollback
+                    // when disposed if either commands fails
+                    transaction.Commit();
 
-                        _logger?.LogInformation(
-                            $"Downgrade to {targetLocalVersion} (DB {_dbProvider.DbName}) completed.");
-                    }
-                    catch (Exception e)
-                    {
-                        _logger?.LogError(e, $"Error while downgrade to {migration.Version}: {e.Message}");
-                        throw;
-                    }
+                    _logger?.LogInformation($"Downgrade to {targetLocalVersion} (DB {_dbProvider.DbName}) completed.");
                 }
             }
 

--- a/src/Curiosity.Migrations/Properties/AssemblyInfo.cs
+++ b/src/Curiosity.Migrations/Properties/AssemblyInfo.cs
@@ -19,5 +19,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("527ae969-df3b-487c-8032-f3476d793e08")]
 
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0")]
-[assembly: AssemblyFileVersion("2.1.0")]
+[assembly: AssemblyVersion("2.2.0")]
+[assembly: AssemblyFileVersion("2.2.0")]


### PR DESCRIPTION
Exception was logged twice: at first time it was logged in Upgrade/DowngradeAsync() and then, after rethrow, it was also logged in MigrateAsync. 